### PR TITLE
Dockerfile for agv on Raspbian

### DIFF
--- a/agv/docker/Dockerfile
+++ b/agv/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ros:melodic-ros-base
+
+RUN apt update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ros-melodic-cv-bridge \
+    ros-melodic-image-transport \
+    ros-melodic-compressed-image-transport
+
+RUN git clone https://github.com/WiringPi/WiringPi \
+    && cd WiringPi \
+    && ./build

--- a/agv/docker/Dockerfile
+++ b/agv/docker/Dockerfile
@@ -4,7 +4,8 @@ RUN apt update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ros-melodic-cv-bridge \
     ros-melodic-image-transport \
-    ros-melodic-compressed-image-transport
+    ros-melodic-compressed-image-transport \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/WiringPi/WiringPi \
     && cd WiringPi \


### PR DESCRIPTION
I created Dockerfile and it's based on `ros:melodic-ros-base` and includes the following packages:

- ros-melodic-cv-bridge
- ros-melodic-image-transport
- ros-melodic-compressed-image-transport
- WiringPi

I pushed the build image on [Docker Hub](https://hub.docker.com/repository/docker/ramesses2nd/agv).

Could you review Dockerfile and the image on Docker Hub?